### PR TITLE
User Theming!

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -190,6 +190,126 @@
         "glob": "7.1.7"
       }
     },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "13.4.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.6.tgz",
+      "integrity": "sha512-ahi6VP98o4HV19rkOXPSUu+ovfHfUxbJQ7VVJ7gL2FnZRr7onEFC1oGQ6NQHpm8CxpIzSSBW79kumlFMOmZVjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "13.4.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.4.6.tgz",
+      "integrity": "sha512-13cXxKFsPJIJKzUqrU5XB1mc0xbUgYsRcdH6/rB8c4NMEbWGdtD4QoK9ShN31TZdePpD4k416Ur7p+deMIxnnA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "13.4.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.6.tgz",
+      "integrity": "sha512-Ti+NMHEjTNktCVxNjeWbYgmZvA2AqMMI2AMlzkXsU7W4pXCMhrryAmAIoo+7YdJbsx01JQWYVxGe62G6DoCLaA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "13.4.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.6.tgz",
+      "integrity": "sha512-OHoC6gO7XfjstgwR+z6UHKlvhqJfyMtNaJidjx3sEcfaDwS7R2lqR5AABi8PuilGgi0BO0O0sCXqLlpp3a0emQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "13.4.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.6.tgz",
+      "integrity": "sha512-zHZxPGkUlpfNJCboUrFqwlwEX5vI9LSN70b8XEb0DYzzlrZyCyOi7hwDp/+3Urm9AB7YCAJkgR5Sp1XBVjHdfQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "13.4.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.6.tgz",
+      "integrity": "sha512-K/Y8lYGTwTpv5ME8PSJxwxLolaDRdVy+lOd9yMRMiQE0BLUhtxtCWC9ypV42uh9WpLjoaD0joOsB9Q6mbrSGJg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "13.4.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.6.tgz",
+      "integrity": "sha512-U6LtxEUrjBL2tpW+Kr1nHCSJWNeIed7U7l5o7FiKGGwGgIlFi4UHDiLI6TQ2lxi20fAU33CsruV3U0GuzMlXIw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "13.4.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.6.tgz",
+      "integrity": "sha512-eEBeAqpCfhdPSlCZCayjCiyIllVqy4tcqvm1xmg3BgJG0G5ITiMM4Cw2WVeRSgWDJqQGRyyb+q8Y2ltzhXOWsQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@next/swc-win32-x64-msvc": {
       "version": "13.4.6",
       "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.6.tgz",
@@ -4289,126 +4409,6 @@
       "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/@next/swc-darwin-arm64": {
-      "version": "13.4.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.6.tgz",
-      "integrity": "sha512-ahi6VP98o4HV19rkOXPSUu+ovfHfUxbJQ7VVJ7gL2FnZRr7onEFC1oGQ6NQHpm8CxpIzSSBW79kumlFMOmZVjg==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-darwin-x64": {
-      "version": "13.4.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.4.6.tgz",
-      "integrity": "sha512-13cXxKFsPJIJKzUqrU5XB1mc0xbUgYsRcdH6/rB8c4NMEbWGdtD4QoK9ShN31TZdePpD4k416Ur7p+deMIxnnA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "13.4.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.6.tgz",
-      "integrity": "sha512-Ti+NMHEjTNktCVxNjeWbYgmZvA2AqMMI2AMlzkXsU7W4pXCMhrryAmAIoo+7YdJbsx01JQWYVxGe62G6DoCLaA==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "13.4.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.6.tgz",
-      "integrity": "sha512-OHoC6gO7XfjstgwR+z6UHKlvhqJfyMtNaJidjx3sEcfaDwS7R2lqR5AABi8PuilGgi0BO0O0sCXqLlpp3a0emQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "13.4.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.6.tgz",
-      "integrity": "sha512-zHZxPGkUlpfNJCboUrFqwlwEX5vI9LSN70b8XEb0DYzzlrZyCyOi7hwDp/+3Urm9AB7YCAJkgR5Sp1XBVjHdfQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-musl": {
-      "version": "13.4.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.6.tgz",
-      "integrity": "sha512-K/Y8lYGTwTpv5ME8PSJxwxLolaDRdVy+lOd9yMRMiQE0BLUhtxtCWC9ypV42uh9WpLjoaD0joOsB9Q6mbrSGJg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "13.4.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.6.tgz",
-      "integrity": "sha512-U6LtxEUrjBL2tpW+Kr1nHCSJWNeIed7U7l5o7FiKGGwGgIlFi4UHDiLI6TQ2lxi20fAU33CsruV3U0GuzMlXIw==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "13.4.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.6.tgz",
-      "integrity": "sha512-eEBeAqpCfhdPSlCZCayjCiyIllVqy4tcqvm1xmg3BgJG0G5ITiMM4Cw2WVeRSgWDJqQGRyyb+q8Y2ltzhXOWsQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -190,126 +190,6 @@
         "glob": "7.1.7"
       }
     },
-    "node_modules/@next/swc-darwin-arm64": {
-      "version": "13.4.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.6.tgz",
-      "integrity": "sha512-ahi6VP98o4HV19rkOXPSUu+ovfHfUxbJQ7VVJ7gL2FnZRr7onEFC1oGQ6NQHpm8CxpIzSSBW79kumlFMOmZVjg==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-darwin-x64": {
-      "version": "13.4.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.4.6.tgz",
-      "integrity": "sha512-13cXxKFsPJIJKzUqrU5XB1mc0xbUgYsRcdH6/rB8c4NMEbWGdtD4QoK9ShN31TZdePpD4k416Ur7p+deMIxnnA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "13.4.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.6.tgz",
-      "integrity": "sha512-Ti+NMHEjTNktCVxNjeWbYgmZvA2AqMMI2AMlzkXsU7W4pXCMhrryAmAIoo+7YdJbsx01JQWYVxGe62G6DoCLaA==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "13.4.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.6.tgz",
-      "integrity": "sha512-OHoC6gO7XfjstgwR+z6UHKlvhqJfyMtNaJidjx3sEcfaDwS7R2lqR5AABi8PuilGgi0BO0O0sCXqLlpp3a0emQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "13.4.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.6.tgz",
-      "integrity": "sha512-zHZxPGkUlpfNJCboUrFqwlwEX5vI9LSN70b8XEb0DYzzlrZyCyOi7hwDp/+3Urm9AB7YCAJkgR5Sp1XBVjHdfQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-musl": {
-      "version": "13.4.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.6.tgz",
-      "integrity": "sha512-K/Y8lYGTwTpv5ME8PSJxwxLolaDRdVy+lOd9yMRMiQE0BLUhtxtCWC9ypV42uh9WpLjoaD0joOsB9Q6mbrSGJg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "13.4.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.6.tgz",
-      "integrity": "sha512-U6LtxEUrjBL2tpW+Kr1nHCSJWNeIed7U7l5o7FiKGGwGgIlFi4UHDiLI6TQ2lxi20fAU33CsruV3U0GuzMlXIw==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "13.4.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.6.tgz",
-      "integrity": "sha512-eEBeAqpCfhdPSlCZCayjCiyIllVqy4tcqvm1xmg3BgJG0G5ITiMM4Cw2WVeRSgWDJqQGRyyb+q8Y2ltzhXOWsQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/@next/swc-win32-x64-msvc": {
       "version": "13.4.6",
       "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.6.tgz",
@@ -4409,6 +4289,126 @@
       "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "13.4.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.6.tgz",
+      "integrity": "sha512-ahi6VP98o4HV19rkOXPSUu+ovfHfUxbJQ7VVJ7gL2FnZRr7onEFC1oGQ6NQHpm8CxpIzSSBW79kumlFMOmZVjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "13.4.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.4.6.tgz",
+      "integrity": "sha512-13cXxKFsPJIJKzUqrU5XB1mc0xbUgYsRcdH6/rB8c4NMEbWGdtD4QoK9ShN31TZdePpD4k416Ur7p+deMIxnnA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "13.4.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.6.tgz",
+      "integrity": "sha512-Ti+NMHEjTNktCVxNjeWbYgmZvA2AqMMI2AMlzkXsU7W4pXCMhrryAmAIoo+7YdJbsx01JQWYVxGe62G6DoCLaA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "13.4.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.6.tgz",
+      "integrity": "sha512-OHoC6gO7XfjstgwR+z6UHKlvhqJfyMtNaJidjx3sEcfaDwS7R2lqR5AABi8PuilGgi0BO0O0sCXqLlpp3a0emQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "13.4.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.6.tgz",
+      "integrity": "sha512-zHZxPGkUlpfNJCboUrFqwlwEX5vI9LSN70b8XEb0DYzzlrZyCyOi7hwDp/+3Urm9AB7YCAJkgR5Sp1XBVjHdfQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "13.4.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.6.tgz",
+      "integrity": "sha512-K/Y8lYGTwTpv5ME8PSJxwxLolaDRdVy+lOd9yMRMiQE0BLUhtxtCWC9ypV42uh9WpLjoaD0joOsB9Q6mbrSGJg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "13.4.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.6.tgz",
+      "integrity": "sha512-U6LtxEUrjBL2tpW+Kr1nHCSJWNeIed7U7l5o7FiKGGwGgIlFi4UHDiLI6TQ2lxi20fAU33CsruV3U0GuzMlXIw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "13.4.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.6.tgz",
+      "integrity": "sha512-eEBeAqpCfhdPSlCZCayjCiyIllVqy4tcqvm1xmg3BgJG0G5ITiMM4Cw2WVeRSgWDJqQGRyyb+q8Y2ltzhXOWsQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     }
   }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import NavBar from "@/components/navbar";
 import "./globals.css";
 import { Inter } from "next/font/google";
 import Providers from "@/components/providers";
+import "../theme/_import.tsx";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -18,9 +19,17 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
+
+  /* it should be noted that chrome extentions that add classes to html will cause
+     next to soft-throw "Prop `className` did not match", EG:
+
+     Warning: Prop `className` did not match. Server: "original dzmwtxok idc0_343" Client: "original"
+
+     this can be ignored!
+  */
   return (
-    <html lang="en">
-      <body className={inter.className}>
+    <html lang="en" className="original">
+      <body className={`${inter.className} bg-[color:var(--bg0)] text-[color:var(--text)]`}>
         <Providers>
           <NavBar />
           <div className="m-auto max-w-7xl px-1 py-1">{children}</div>

--- a/src/components/history/historyModal/index.tsx
+++ b/src/components/history/historyModal/index.tsx
@@ -52,15 +52,15 @@ export default function HistoryModal({
   if (!opened) return null;
   return (
     <div
-      className="fixed inset-0 bg-[#474678] backdrop-blur-sm bg-opacity-75 flex justify-center items-center"
+      className="fixed inset-0 bg-transparent backdrop-blur-sm bg-opacity-75 flex justify-center items-center"
       onClick={() => setOpened(false)}
     >
       <div
-        className=" max-lg:hidden w-fit  max-w-5xl h-fit bg-[#00264F] rounded-md relative"
+        className=" max-lg:hidden w-fit  max-w-5xl h-fit bg-[color:var(--bg0)] rounded-md relative"
         onClick={(e) => e.stopPropagation()}
       >
         <button
-          className="text-xl absolute top-1 right-1 hover:bg-[#474678] rounded-md"
+          className="text-xl absolute top-1 right-1 hover:bg-[color:var(--bg0)] rounded-md"
           onClick={() => setOpened(false)}
         >
           <svg
@@ -99,26 +99,26 @@ export default function HistoryModal({
           </div>
           <div className="flex gap-1 pt-1 items-center justify-start">
             <button
-              className="w-32 bg-green-600 hover:bg-green-500 rounded p-1"
+              className="w-32 bg-[color:var(--green)] hover:bg-[color:var(--green-50)] rounded p-1"
               onClick={() => downloadImage(data)}
             >
               Save
             </button>
             <button
-              className="w-32 bg-green-600 hover:bg-green-500 rounded p-1"
+              className="w-32 bg-[color:var(--green)] hover:bg-[color:var(--green-50)] rounded p-1"
               onClick={() => downloadPrompt(data)}
             >
               Save Tags
             </button>
             <button
-              className="w-32 bg-green-600 hover:bg-green-500 rounded p-1 disabled:bg-gray-500"
+              className="w-32 bg-[color:var(--green)] hover:bg-[color:var(--green-50)] rounded p-1 disabled:bg-gray-500"
               onClick={() => onReplicate()}
               disabled={isDisabled}
             >
               Replicate
             </button>
             <button
-              className="w-32 bg-red-600 hover:bg-red-500 rounded p-1"
+              className="w-32 bg-[color:var(--red)] hover:bg-[color:var(--red-50)] rounded p-1"
               onClick={() => onDelete()}
             >
               Delete
@@ -169,26 +169,26 @@ export default function HistoryModal({
           </div>
           <div className="flex gap-2 justify-center">
             <button
-              className="bg-green-600 hover:bg-green-500 rounded w-24"
+              className="bg-[color:var(--green)] hover:bg-[color:var(--green-50)] rounded w-24"
               onClick={() => downloadImage(data)}
             >
               Save
             </button>
             <button
-              className="bg-green-600 hover:bg-green-500 rounded w-24"
+              className="bg-[color:var(--green)] hover:bg-[color:var(--green-50)] rounded w-24"
               onClick={() => downloadPrompt(data)}
             >
               Save Tags
             </button>
             <button
-              className="bg-green-600 hover:bg-green-500 rounded w-24 disabled:bg-gray-500"
+              className="bg-[color:var(--green)] hover:bg-[color:var(--green-50)] rounded w-24 disabled:bg-gray-500"
               onClick={() => onReplicate()}
               disabled={isDisabled}
             >
               Replicate
             </button>
             <button
-              className="bg-red-600 hover:bg-red-500 rounded w-24"
+              className="bg-[color:var(--red)] hover:bg-[color:var(--red-50)] rounded w-24"
               onClick={() => onDelete()}
             >
               Delete

--- a/src/components/history/index.tsx
+++ b/src/components/history/index.tsx
@@ -28,7 +28,7 @@ export default function History({
           Recently Generated Images
         </h1>
         <button
-          className="bg-red-600 hover:bg-red-500 rounded px-2 py-1 text-sm font-bold mt-1"
+          className="bg-[var(--red)] text-[color:var(--text-on-color)] hover:bg-[var(--red-50)] rounded px-2 py-1 text-sm font-bold mt-1"
           onClick={() => deleteAll()}
         >
           Delete All

--- a/src/components/importTagsModal/index.tsx
+++ b/src/components/importTagsModal/index.tsx
@@ -40,7 +40,7 @@ export default function ImportTagsModal({
   if (!opened) return null;
   return (
     <div
-      className="fixed inset-0 bg-[#00264F] backdrop-blur-sm bg-opacity-75 flex justify-center items-center"
+      className="fixed inset-0 bg-transparent backdrop-blur-sm bg-opacity-75 flex justify-center items-center"
       onClick={() => setOpened(false)}
     >
       <form
@@ -48,11 +48,11 @@ export default function ImportTagsModal({
         className="w-full flex justify-center max-w-md"
       >
         <div
-          className="max-lg:hidden h-fit w-full bg-[#002C5C] rounded-md relative"
+          className="max-lg:hidden h-fit w-full bg-[color:var(--bg0)] rounded-md relative"
           onClick={(e) => e.stopPropagation()}
         >
           <button
-            className="text-xl absolute top-1 right-1 hover:bg-[#00264F] rounded-md"
+            className="text-xl absolute top-1 right-1 hover:bg-[color:var(--bg1)] rounded-md"
             onClick={() => setOpened(false)}
           >
             <svg
@@ -73,7 +73,7 @@ export default function ImportTagsModal({
           <div className="p-2 w-full flex flex-col gap-2">
             <p className="text-bold text-sm">Select Site</p>
             <select
-              className="w-full bg-[#474678] h-8"
+              className="w-full bg-[color:var(--bg3)] h-8"
               {...register("site")}
               value={getValues("site")}
               onChange={(x) => setValue("site", x.target.value)}
@@ -83,12 +83,12 @@ export default function ImportTagsModal({
             </select>
             <p className="text-bold text-sm">Input URL</p>
             <input
-              className="w-full bg-[#474678] h-8 pl-1 text-sm"
+              className="w-full bg-[color:var(--bg3)] h-8 pl-1 text-sm"
               {...register("url")}
               onChange={(x) => setValue("url", x.target.value)}
             />
             <button
-              className="w-full bg-green-600 hover:bg-green-500 rounded py-1 px-1 text-bold text-md"
+              className="w-full bg-[color:var(--green)] hover:bg-[color:var(--green-50)] rounded py-1 px-1 text-bold text-md"
               type="submit"
             >
               Import
@@ -96,11 +96,11 @@ export default function ImportTagsModal({
           </div>
         </div>
         <div
-          className="lg:hidden w-3/4 bg-[#002C5C] rounded-md relative"
+          className="lg:hidden w-3/4 bg-[color:var(--bg0)] rounded-md relative"
           onClick={(e) => e.stopPropagation()}
         >
           <button
-            className="text-xl w-fit absolute top-1 right-1 hover:bg-[#474678] rounded-md"
+            className="text-xl w-fit absolute top-1 right-1 hover:bg-[color:var(--bg0)] rounded-md"
             onClick={() => setOpened(false)}
           >
             <svg
@@ -121,7 +121,7 @@ export default function ImportTagsModal({
           <div className="p-2 w-full flex flex-col gap-2">
             <p className="text-bold text-sm">Select Site</p>
             <select
-              className="w-full bg-[#474678] h-8"
+              className="w-full bg-[color:var(--bg3)] h-8"
               {...register("site")}
               value={getValues("site")}
               onChange={(x) => setValue("site", x.target.value)}
@@ -131,12 +131,12 @@ export default function ImportTagsModal({
             </select>
             <p className="text-bold text-sm">Input URL</p>
             <input
-              className="w-full bg-[#474678] h-8 pl-1 text-sm"
+              className="w-full bg-[color:var(--bg3)] h-8 pl-1 text-sm"
               {...register("url")}
               onChange={(x) => setValue("url", x.target.value)}
             />
             <button
-              className="w-full bg-green-600 hover:bg-green-500 rounded py-1 px-1 text-bold text-md"
+              className="w-full bg-[color:var(--green)] hover:bg-[color:var(--green-50)] rounded py-1 px-1 text-bold text-md"
               type="submit"
             >
               Import

--- a/src/components/main/index.tsx
+++ b/src/components/main/index.tsx
@@ -16,6 +16,7 @@ import ImportTagsModal from "@/components/importTagsModal";
 import downloadImage from "@/utils/downloadImage";
 import downloadPrompt from "@/utils/downloadPrompt";
 import toast from "react-hot-toast";
+import "../../theme/_import.tsx";
 
 export default function Main() {
   const [genFetched, setGenFetched] = React.useState<boolean>(false);
@@ -107,6 +108,11 @@ export default function Main() {
     });
   };
 
+	var [isDev, setDev] = React.useState(false);
+	React.useEffect(()=>{
+		setDev( localStorage.getItem('user.dev') )
+	});
+
   return (
     <>
       <div className="w-full">
@@ -132,7 +138,7 @@ export default function Main() {
                   <p className="text-sm">Positive Prompts</p>
                   <textarea
                     {...register("positivePrompts")}
-                    className="bg-[#00264F] w-full p-1 resize-none h-36"
+                    className="bg-[color:var(--bg2)] w-full p-1 resize-none h-36"
                     onChange={(x) =>
                       setValue("positivePrompts", x.target.value)
                     }
@@ -143,7 +149,7 @@ export default function Main() {
                   <p className="text-sm">Negative Prompts</p>
                   <textarea
                     {...register("negativePrompts")}
-                    className="bg-[#00264F] w-full p-1 resize-none h-36"
+                    className="bg-[color:var(--bg2)] w-full p-1 resize-none h-36"
                     onChange={(x) =>
                       setValue("negativePrompts", x.target.value)
                     }
@@ -191,7 +197,7 @@ export default function Main() {
                     <p className="text-bold text-sm">Model</p>
                     <select
                       {...register("model")}
-                      className="w-full bg-[#00264F] h-8"
+                      className="w-full bg-[color:var(--bg2)] h-8"
                       placeholder="Select Model"
                       onChange={(x) => setValue("model", x.target.value)}
                       disabled={disableInput}
@@ -206,7 +212,7 @@ export default function Main() {
                     <p className="text-bold text-sm">Seed</p>
                     <input
                       {...register("seed")}
-                      className="bg-[#00264F] w-full h-8 p-1"
+                      className="bg-[color:var(--bg2)] w-full h-8 p-1"
                       min={-1}
                       onChange={(x) =>
                         !Number.isNaN(Number(x.target.value)) ||
@@ -230,7 +236,7 @@ export default function Main() {
                   <div className="pl-2 gap-4 flex place-self-end">
                     <button
                       type="button"
-                      className="text-sm bg-[#00264F] hover:bg-[#3a3a7c] rounded-md px-1 disabled:bg-gray-600"
+                      className="text-sm text-[color:var(--text-on-color)] bg-[color:var(--blue)] hover:bg-[color:var(--blue-60)] rounded-md px-1 disabled:bg-[color:var(--bg3)] disabled:outline-current"
                       onClick={() => setValue("seed", genData?.seed)}
                       disabled={disableInput}
                     >
@@ -238,7 +244,7 @@ export default function Main() {
                     </button>
                     <button
                       type="button"
-                      className="text-sm bg-[#00264F] hover:bg-[#3a3a7c] rounded-md px-1 disabled:bg-gray-600"
+                      className="text-sm text-[color:var(--text-on-color)] bg-[color:var(--blue)] hover:bg-[color:var(--blue-60)] rounded-md px-1 disabled:bg-[color:var(--bg3)] disabled:outline-current"
                       onClick={() => setValue("seed", -1)}
                       disabled={disableInput}
                     >
@@ -250,7 +256,7 @@ export default function Main() {
                   <div>
                     <button
                       type="submit"
-                      className="w-full font-bold py-1 bg-[#337357] hover:bg-[#3f906b] rounded-lg text-xl disabled:bg-gray-600"
+                      className="w-full font-bold py-1 text-[color:var(--text-on-color)] bg-[color:var(--green)] hover:bg-[color:var(--green-50)] rounded-lg text-xl disabled:opacity-30"
                       disabled={
                         disableInput || cooldown > 0 || !getValues("model")
                       }
@@ -261,7 +267,7 @@ export default function Main() {
                   <div className="gap-2 align-middle flex pl-2 pt-1 w-fit">
                     <button
                       type="button"
-                      className="font-bold py-1 bg-[#337357] hover:bg-[#3f906b] rounded-lg px-1 text-sm disabled:bg-gray-600"
+                      className="font-bold py-1 text-[color:var(--text-on-color)] bg-[color:var(--green)] hover:bg-[color:var(--green-50)] rounded-lg px-1 text-sm disabled:opacity-30"
                       disabled={disableInput || !genData}
                       onClick={() => downloadImage(genData!)}
                     >
@@ -269,7 +275,7 @@ export default function Main() {
                     </button>
                     <button
                       type="button"
-                      className="font-bold py-1 bg-[#337357] hover:bg-[#3f906b] rounded-lg px-1 text-sm disabled:bg-gray-600"
+                      className="font-bold py-1 text-[color:var(--text-on-color)] bg-[color:var(--green)] hover:bg-[color:var(--green-50)] rounded-lg px-1 text-sm disabled:opacity-30"
                       disabled={disableInput || !genData}
                       onClick={() => downloadPrompt(genData!)}
                     >
@@ -277,7 +283,7 @@ export default function Main() {
                     </button>
                     <button
                       type="button"
-                      className="font-bold py-1 bg-[#337357] hover:bg-[#3f906b] rounded-lg px-1 text-sm disabled:bg-gray-600"
+                      className="font-bold py-1 text-[color:var(--text-on-color)] bg-[color:var(--green)] hover:bg-[color:var(--green-50)] rounded-lg px-1 text-sm disabled:opacity-30"
                       disabled={disableInput}
                       onClick={() => setImportTagsOpened(true)}
                     >
@@ -285,7 +291,7 @@ export default function Main() {
                     </button>
                     <button
                       type="button"
-                      className="font-bold py-1 bg-red-600 hover:bg-red-500 rounded-lg px-1 text-sm disabled:bg-gray-600"
+                      className="font-bold py-1 text-[color:var(--text-on-color)] bg-[color:var(--red)] hover:bg-[var(--red-50)] rounded-lg px-1 text-sm disabled:opacity-30"
                       onClick={() => reset()}
                       disabled={disableInput}
                     >
@@ -309,7 +315,7 @@ export default function Main() {
               <div className="flex justify-center">
                 <button
                   type="submit"
-                  className="w-full max-w-lg font-bold px-2 py-1 bg-[#337357] hover:bg-[#3f906b] rounded-lg text-xl disabled:bg-gray-600"
+                  className="w-full text-[color:var(--text-on-color)] max-w-lg font-bold px-2 py-1 bg-[color:var(--green)] hover:bg-[color:var(--green-50)] rounded-lg text-xl disabled:opacity-30"
                   disabled={disableInput || cooldown > 0 || !getValues("model")}
                 >
                   {`Generate ${cooldown > 0 ? `(${cooldown})` : ""}`}
@@ -319,7 +325,7 @@ export default function Main() {
               <div className="flex justify-center gap-2 w-full">
                 <button
                   type="button"
-                  className="font-bold  bg-[#337357] hover:bg-[#3f906b] rounded-lg px-2 text-sm disabled:bg-gray-600"
+                  className="font-bold text-[color:var(--text-on-color)] bg-[color:var(--green)] hover:bg-[color:var(--green-50)] rounded-lg px-2 text-sm disabled:opacity-30"
                   disabled={disableInput || !genData}
                   onClick={() => downloadImage(genData!)}
                 >
@@ -327,7 +333,7 @@ export default function Main() {
                 </button>
                 <button
                   type="button"
-                  className="font-bold bg-[#337357] hover:bg-[#3f906b] rounded-lg px-2 text-sm disabled:bg-gray-600"
+                  className="font-bold text-[color:var(--text-on-color)] bg-[color:var(--green)] hover:bg-[color:var(--green-50)] rounded-lg px-2 text-sm disabled:opacity-30"
                   disabled={disableInput || !genData}
                   onClick={() => downloadPrompt(genData!)}
                 >
@@ -335,7 +341,7 @@ export default function Main() {
                 </button>
                 <button
                   type="button"
-                  className="font-bold py-1 bg-[#337357] hover:bg-[#3f906b] rounded-lg px-2 text-sm disabled:bg-gray-600"
+                  className="font-bold text-[color:var(--text-on-color)] py-1 bg-[color:var(--green)] hover:bg-[color:var(--green-50)] rounded-lg px-2 text-sm disabled:opacity-30"
                   disabled={disableInput}
                   onClick={() => setImportTagsOpened(true)}
                 >
@@ -343,7 +349,7 @@ export default function Main() {
                 </button>
                 <button
                   type="button"
-                  className="font-bold py-1 bg-red-600 hover:bg-red-500 rounded-lg px-2 text-sm disabled:bg-gray-600"
+                  className="font-bold text-[color:var(--text-on-color)] py-1 bg-[color:var(--red)] hover:bg-[color:var(--red-50)] rounded-lg px-2 text-sm disabled:opacity-30"
                   onClick={() => reset()}
                   disabled={disableInput}
                 >
@@ -355,7 +361,7 @@ export default function Main() {
               <p className="text-sm">Positive Prompts</p>
               <textarea
                 {...register("positivePrompts")}
-                className="bg-[#00264F] w-full p-1 resize-none h-32"
+                className="bg-[color:var(--bg2)] w-full p-1 resize-none h-32"
                 onChange={(x) => setValue("positivePrompts", x.target.value)}
                 disabled={disableInput}
               />
@@ -364,7 +370,7 @@ export default function Main() {
               <p className="text-sm">Negative Prompts</p>
               <textarea
                 {...register("negativePrompts")}
-                className="bg-[#00264F] w-full p-1 resize-none h-32"
+                className="bg-[color:var(--bg2)] w-full p-1 resize-none h-32"
                 onChange={(x) => setValue("negativePrompts", x.target.value)}
                 disabled={disableInput}
               />
@@ -408,7 +414,7 @@ export default function Main() {
                 <p className="text-bold text-sm">Model</p>
                 <select
                   {...register("model")}
-                  className="w-full bg-[#00264F] h-8"
+                  className="w-full bg-[color:var(--bg2)] h-8"
                   placeholder="Select Model"
                   onChange={(x) => setValue("model", x.target.value)}
                   disabled={disableInput}
@@ -423,7 +429,7 @@ export default function Main() {
                 <p className="text-bold text-sm">Seed</p>
                 <input
                   {...register("seed")}
-                  className="bg-[#00264F] w-full h-8 p-1"
+                  className="bg-[color:var(--bg2)] w-full h-8 p-1"
                   onChange={(x) =>
                     !Number.isNaN(Number(x.target.value)) ||
                     x.target.value === "-"
@@ -446,7 +452,7 @@ export default function Main() {
               <div className="pl-2 gap-4 flex place-self-end">
                 <button
                   type="button"
-                  className="text-sm bg-[#00264F] hover:bg-[#3a3a7c] rounded-md px-1 disabled:bg-gray-600"
+                  className="text-sm text-[color:var(--text-on-color)] bg-[color:var(--blue)] hover:bg-[color:var(--blue-60)] rounded-md px-1 disabled:opacity-30"
                   onClick={() => setValue("seed", genData?.seed)}
                   disabled={disableInput}
                 >
@@ -454,7 +460,7 @@ export default function Main() {
                 </button>
                 <button
                   type="button"
-                  className="text-sm bg-[#00264F] hover:bg-[#3a3a7c] rounded-md px-1 disabled:bg-gray-600"
+                  className="text-sm text-[color:var(--text-on-color)] bg-[color:var(--blue)] hover:bg-[color:var(--blue-60)] rounded-md px-1 disabled:bg-[color:var(--bg3)] disabled:outline-current"
                   onClick={() => setValue("seed", -1)}
                   disabled={disableInput}
                 >
@@ -471,6 +477,23 @@ export default function Main() {
         opened={importTagsOpened}
         setValues={setValue}
       />
+
+			{/* this is for creating colourschemes with mui bracketmix */}
+			{isDev?(<>
+				<div className="colourbox flex flex-wrap" style={{width:`${60*11}px`}}>
+					{['red','orange','yellow','green','blue','purple'].map(color=>{
+						return (['-0','-10','-20','-30','-40','','-50','-60','-70','-80','-90']).map((tone,i) => {
+							return (<div key={i} style={{
+								backgroundColor:`var(--${color}${tone})`,
+								color:`var(--text-on-color)`,
+								width:'60px',
+								height:'60px'
+							}} className="cb-item">{color}<br/>{tone}</div>);
+						})
+					})}
+				</div>
+			</>):""}
+
     </>
   );
 }

--- a/src/components/navbar/index.tsx
+++ b/src/components/navbar/index.tsx
@@ -4,13 +4,14 @@ import Link from "next/link";
 import Image from "next/image";
 import cute from "../../../public/cute.gif";
 import React from "react";
+import ThemeSwitcher from "../themeSwitcher/index.tsx"
 
 export default function NavBar() {
   const [opened, setOpened] = React.useState<boolean>(false);
 
   return (
     <>
-      <nav className="bg-[#001933] border-gray-500">
+      <nav className="bg-[color:var(--bg1)] border-gray-500">
         <div className="w-full flex items-center gap-2 mx-auto justify-between px-2 py-1">
           <Link
             href="/"
@@ -19,6 +20,7 @@ export default function NavBar() {
             <Image src={cute} height={48} width={48} alt="cute.gif" />
             <p className="text-xl font-bold">{"Nemu's Waifu Generator"}</p>
           </Link>
+          <ThemeSwitcher />
           <div className="flex items-center gap-2 sm:visible max-sm:hidden px-2">
             <Link
               href="https://twitter.com/waifugeneth"

--- a/src/components/themeSwitcher/index.tsx
+++ b/src/components/themeSwitcher/index.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import React from "react";
+import {themeList} from "../../theme/_list.tsx";
+
+function setEvent(e){
+	console.log(e);
+  var newThemeI = themeList.find(a=>a.identifier === (e?.target?.value || e)).identifier;
+  console.log('changing theme from to', newThemeI);
+
+  /* remove old theme */
+  document.documentElement.classList.remove(...themeList.map( t => t.identifier ));
+
+  /* add new theme */
+  document.documentElement.classList.add(newThemeI);
+  localStorage.setItem('user.theme.identifier', newThemeI);
+}
+
+function Icon(props){
+  return (
+    <svg className="themeActivator text-[color:var(--bg3)] hover:text-[color:var(--text)]" {...props} width="24px" fill="currentColor" viewBox="0 0 32 32" version="1.1">
+      <path d="M20 8h-4v-4h4v4zM28 16v-4h-4v4h4zM28 24v-4h-4v4h4zM8 4v4h4v-4h-4zM20 16h4v4h-4v8h-16v-16h8v-4h4v4h4v4zM16 16h-8v8h8v-8zM28 4h-4v4h4v-4zM20 8v4h4v-4h-4z"></path>
+    </svg>
+  )
+}
+
+function ThemeCard({theme}){
+	return(<>
+		<div
+			className={theme.identifier + " themeCard flex flex-col text-center pt-5 bg-[color:var(--bg0)] outline-8"}
+			title={theme.desc}
+			onClick={ ()=>setEvent(theme.identifier) }
+		>
+
+			<p className="text-[color:var(--text)]">{theme.name}</p>
+
+			<div className="h-2/4 flex flex-col justify-center align-center mt-5">
+				<div className="inline-flex flex-row mx-auto">
+		      <span className="block bg-[color:var(--bg0)]"></span>
+		      <span className="block bg-[color:var(--bg1)]"></span>
+		      <span className="block bg-[color:var(--bg2)]"></span>
+		      <span className="block bg-[color:var(--bg3)]"></span>
+		      <span className="block bg-[color:var(--text)]"></span>
+		      <span className="block bg-[color:var(--darktext)]"></span>
+				</div>
+				<div className="inline-flex flex-row mx-auto">
+		      <span className="block bg-[color:var(--red)]"></span>
+		      <span className="block bg-[color:var(--orange)]"></span>
+		      <span className="block bg-[color:var(--yellow)]"></span>
+		      <span className="block bg-[color:var(--green)]"></span>
+		      <span className="block bg-[color:var(--blue)]"></span>
+		      <span className="block bg-[color:var(--purple)]"></span>
+				</div>
+			</div>
+		</div>
+	</>)
+}
+
+function ThemeCards({setOpen}){
+  return (<div
+		id="ThemeCards" className="flex flex-wrap justify-center border-box"
+		onClick={ ()=>setOpen(false) }
+	>
+    {themeList.map( (theme, idx)=>
+      <ThemeCard theme={theme} key={idx}/>
+    )}
+  </div>)
+}
+
+export default function ThemeSwitcher(){
+  var [isOpen, setOpen] = React.useState<boolean>(false);
+
+  React.useEffect(function(){
+    console.log("themes", themeList);
+
+    if(localStorage.getItem('user.theme.identifier') === null){
+      localStorage.setItem('user.theme.identifier', 'original');
+    }
+
+    // UI starts with class original to make sure page doesnt flashbang the user
+    document.documentElement.classList.remove( "original" );
+    document.documentElement.classList.add( localStorage.getItem('user.theme.identifier') );
+
+  }, []);
+
+
+  return (<>
+    <Icon onClick={ ()=>{setOpen( o=>!o )} }/>
+    <div id={`theme_switcher_${isOpen?"open":"closed"}`} style={isOpen?{}:{top:"-100vh"}} className="fixed left-1/2">
+      <ThemeCards setOpen={setOpen}/>
+    </div>
+  </>);
+}
+/*
+    <div id={`theme_switcher_${isOpen?"open":"closed"}`} style={isOpen?{}:{top:"-50px"}} className="fixed left-1/2">
+      <select id={`stheme-${theme}`} onChange={setEvent} value={theme} className="text-black bg-white">
+        {themeList.map( (theme, idx) =>
+          <option
+            key={theme.identifier}
+            value={theme.identifier}
+          >{theme.name}</option>
+        )}
+      </select>
+    </div>
+*/

--- a/src/components/themeSwitcher/index.tsx
+++ b/src/components/themeSwitcher/index.tsx
@@ -27,14 +27,14 @@ function Icon(props){
 function ThemeCard({theme}){
 	return(<>
 		<div
-			className={theme.identifier + " themeCard flex flex-col text-center pt-5 bg-[color:var(--bg0)] outline-8"}
+			className={theme.identifier + " themeCard flex flex-col text-center bg-[color:var(--bg0)] outline-8"}
 			title={theme.desc}
 			onClick={ ()=>setEvent(theme.identifier) }
 		>
 
 			<p className="text-[color:var(--text)]">{theme.name}</p>
 
-			<div className="h-2/4 flex flex-col justify-center align-center mt-5">
+			<div className="themeCardColours-fr h-2/4 flex flex-col justify-center align-center mt-5">
 				<div className="inline-flex flex-row mx-auto">
 		      <span className="block bg-[color:var(--bg0)]"></span>
 		      <span className="block bg-[color:var(--bg1)]"></span>
@@ -43,7 +43,7 @@ function ThemeCard({theme}){
 		      <span className="block bg-[color:var(--text)]"></span>
 		      <span className="block bg-[color:var(--darktext)]"></span>
 				</div>
-				<div className="inline-flex flex-row mx-auto">
+				<div className="themeCardColours-lr inline-flex flex-row mx-auto">
 		      <span className="block bg-[color:var(--red)]"></span>
 		      <span className="block bg-[color:var(--orange)]"></span>
 		      <span className="block bg-[color:var(--yellow)]"></span>

--- a/src/theme/_dynamic_theme.css
+++ b/src/theme/_dynamic_theme.css
@@ -1,0 +1,131 @@
+/* this file is for themes that cannot be applied with tailwind */
+#theme_switcher_open{
+	top:0px;
+	padding-top:10px;
+}
+#theme_switcher_open,
+#theme_switcher_closed {
+	transform:translateX(-50%);
+	transition:top .2s ease-in-out;
+}
+.themeCard span{
+	width:12px;
+	height:12px;
+}
+.themeCard{
+	width:calc(100% / 8);
+	height:12em;
+	position:relative;
+	transition:top .1s linear, left .1s linear, box-shadow .1s linear;
+	left:0px;
+	top:0px;
+	box-shadow:none;
+}
+.themeCard:hover{
+	box-shadow:-1px 1px 0px var(--bg0), -2px 2px 0px var(--bg1),-3px 3px 0px var(--bg2),-4px 4px 0px var(--bg3);
+	top:-4px;
+	left:4px;
+	z-index:99;
+}
+.themeActivator{
+	transition:color .1s linear;
+}
+.themeActivator:hover{
+	filter:drop-shadow(3px 3px 0 var(--bg3))
+}
+
+#ThemeCards{
+	width:100vw;
+	z-index:50;
+	position:relative;
+}
+/* calculate bracketmix colours */
+:root{
+	--red-0:color-mix(in srgb, var(--red) 10%, var(--bg0));
+	--red-10:color-mix(in srgb, var(--red) 30%, var(--bg0));
+	--red-20:color-mix(in srgb, var(--red) 50%, var(--bg0));
+	--red-30:color-mix(in srgb, var(--red) 70%, var(--bg0));
+	--red-40:color-mix(in srgb, var(--red) 90%, var(--bg0));
+	--red-50:color-mix(in srgb, var(--red) 90%, var(--text));
+	--red-60:color-mix(in srgb, var(--red) 70%, var(--text));
+	--red-70:color-mix(in srgb, var(--red) 50%, var(--text));
+	--red-80:color-mix(in srgb, var(--red) 30%, var(--text));
+	--red-90:color-mix(in srgb, var(--red) 10%, var(--text));
+
+	--orange-0:color-mix(in srgb, var(--orange) 10%, var(--bg0));
+	--orange-10:color-mix(in srgb, var(--orange) 30%, var(--bg0));
+	--orange-20:color-mix(in srgb, var(--orange) 50%, var(--bg0));
+	--orange-30:color-mix(in srgb, var(--orange) 70%, var(--bg0));
+	--orange-40:color-mix(in srgb, var(--orange) 90%, var(--bg0));
+	--orange-50:color-mix(in srgb, var(--orange) 90%, var(--text));
+	--orange-60:color-mix(in srgb, var(--orange) 70%, var(--text));
+	--orange-70:color-mix(in srgb, var(--orange) 50%, var(--text));
+	--orange-80:color-mix(in srgb, var(--orange) 30%, var(--text));
+	--orange-90:color-mix(in srgb, var(--orange) 10%, var(--text));
+
+	--yellow-0:color-mix(in srgb, var(--yellow) 10%, var(--bg0));
+	--yellow-10:color-mix(in srgb, var(--yellow) 30%, var(--bg0));
+	--yellow-20:color-mix(in srgb, var(--yellow) 50%, var(--bg0));
+	--yellow-30:color-mix(in srgb, var(--yellow) 70%, var(--bg0));
+	--yellow-40:color-mix(in srgb, var(--yellow) 90%, var(--bg0));
+	--yellow-50:color-mix(in srgb, var(--yellow) 90%, var(--text));
+	--yellow-60:color-mix(in srgb, var(--yellow) 70%, var(--text));
+	--yellow-70:color-mix(in srgb, var(--yellow) 50%, var(--text));
+	--yellow-80:color-mix(in srgb, var(--yellow) 30%, var(--text));
+	--yellow-90:color-mix(in srgb, var(--yellow) 10%, var(--text));
+
+	--green-0:color-mix(in srgb, var(--green) 10%, var(--bg0));
+	--green-10:color-mix(in srgb, var(--green) 30%, var(--bg0));
+	--green-20:color-mix(in srgb, var(--green) 50%, var(--bg0));
+	--green-30:color-mix(in srgb, var(--green) 70%, var(--bg0));
+	--green-40:color-mix(in srgb, var(--green) 90%, var(--bg0));
+	--green-50:color-mix(in srgb, var(--green) 90%, var(--text));
+	--green-60:color-mix(in srgb, var(--green) 70%, var(--text));
+	--green-70:color-mix(in srgb, var(--green) 50%, var(--text));
+	--green-80:color-mix(in srgb, var(--green) 30%, var(--text));
+	--green-90:color-mix(in srgb, var(--green) 10%, var(--text));
+
+	--blue-0:color-mix(in srgb, var(--blue) 10%, var(--bg0));
+	--blue-10:color-mix(in srgb, var(--blue) 30%, var(--bg0));
+	--blue-20:color-mix(in srgb, var(--blue) 50%, var(--bg0));
+	--blue-30:color-mix(in srgb, var(--blue) 70%, var(--bg0));
+	--blue-40:color-mix(in srgb, var(--blue) 90%, var(--bg0));
+	--blue-50:color-mix(in srgb, var(--blue) 90%, var(--text));
+	--blue-60:color-mix(in srgb, var(--blue) 70%, var(--text));
+	--blue-70:color-mix(in srgb, var(--blue) 50%, var(--text));
+	--blue-80:color-mix(in srgb, var(--blue) 30%, var(--text));
+	--blue-90:color-mix(in srgb, var(--blue) 10%, var(--text));
+
+	--purple-0:color-mix(in srgb, var(--purple) 10%, var(--bg0));
+	--purple-10:color-mix(in srgb, var(--purple) 30%, var(--bg0));
+	--purple-20:color-mix(in srgb, var(--purple) 50%, var(--bg0));
+	--purple-30:color-mix(in srgb, var(--purple) 70%, var(--bg0));
+	--purple-40:color-mix(in srgb, var(--purple) 90%, var(--bg0));
+	--purple-50:color-mix(in srgb, var(--purple) 90%, var(--text));
+	--purple-60:color-mix(in srgb, var(--purple) 70%, var(--text));
+	--purple-70:color-mix(in srgb, var(--purple) 50%, var(--text));
+	--purple-80:color-mix(in srgb, var(--purple) 30%, var(--text));
+	--purple-90:color-mix(in srgb, var(--purple) 10%, var(--text));
+}
+
+/* LIGHT themes */
+:root.google-light,
+:root.greenhouse,
+:root.light,
+:root.solarised_light{}
+
+/* DARK themes */
+:root.dracula,
+:root.google-dark,
+:root.greenhouse,
+:root.hxve,
+:root.monokai,
+:root.monokai_pro,
+:root.monokai_prosep,
+:root.nineteeneighty,
+:root.oled,
+:root.original,
+:root.proton,
+:root.solarised_dark,
+:root.t_winter,
+:root.zenburn{}

--- a/src/theme/_dynamic_theme.css
+++ b/src/theme/_dynamic_theme.css
@@ -20,6 +20,7 @@
 	left:0px;
 	top:0px;
 	box-shadow:none;
+	padding-top:1.25rem;
 }
 .themeCard:hover{
 	box-shadow:-1px 1px 0px var(--bg0), -2px 2px 0px var(--bg1),-3px 3px 0px var(--bg2),-4px 4px 0px var(--bg3);
@@ -32,6 +33,17 @@
 }
 .themeActivator:hover{
 	filter:drop-shadow(3px 3px 0 var(--bg3))
+}
+
+@media( max-width: 700px){
+	.themeCard{
+		width:calc(100% / 4);
+		height:6em;
+		padding-top:.6rem
+	}
+	.themeCardColours-fr{
+		margin-top:.6rem;
+	}
 }
 
 #ThemeCards{

--- a/src/theme/_import.tsx
+++ b/src/theme/_import.tsx
@@ -1,0 +1,17 @@
+import "./_dynamic_theme.css";
+import "./dracula.css";
+import "./google-dark.css";
+import "./google-light.css";
+import "./greenhouse.css";
+import "./hxve.css";
+import "./monokai.css";
+import "./monokai_pro.css";
+import "./monokai_prosep.css";
+import "./nineteeneighty.css";
+import "./oled.css";
+import "./original.css";
+import "./proton.css";
+import "./solarised_dark.css";
+import "./solarised_light.css";
+import "./t_winter.css";
+import "./zenburn.css";

--- a/src/theme/_list.tsx
+++ b/src/theme/_list.tsx
@@ -1,0 +1,82 @@
+var themeList = [{
+"name": "dracula UI",
+"desc": "an impending grey set of colours",
+"auth": "draculatheme.com",
+"identifier":"dracula"
+},{
+"name": "mUI dark",
+"desc": "the dark colours of alphabet corporation",
+"auth": "Google",
+"identifier":"google-dark"
+},{
+"name": "mUI light",
+"desc": "the light colours of alphabet corporation",
+"auth": "Google",
+"identifier":"google-light"
+},{
+"name": "greenhouse",
+"desc": "i cant tell if this is a light or a dark theme to be honest",
+"auth": "hoax",
+"identifier":"greenhouse"
+},{
+"name": "hxve terminal",
+"desc": "a boring, slate-grey theme",
+"auth": "hoax",
+"identifier":"hxve"
+},{
+"name": "monokai",
+"desc": "a sandy theme",
+"auth": "Sublime Text 2",
+"identifier":"monokai"
+},{
+"name": "monokai pro",
+"desc": "monokai pro, the sequel to monokai",
+"auth": "Sublime Text 3",
+"identifier":"monokai_pro"
+},{
+"name": "monokai desert",
+"desc": "a not-so-light version of monokai pro",
+"auth": "Sublime Text 3 + hoax",
+"identifier":"monokai_prosep"
+},{
+"name": "1980",
+"desc": "a retro set of colours",
+"author": "hoax",
+"identifier":"nineteeneighty"
+},{
+"name": "OLED Black",
+"desc": "for modern display panels",
+"auth": "hoax",
+"identifier":"oled"
+},{
+"name": "nemusona UI",
+"desc": "a deep-blue set of colours",
+"auth": "nemu",
+"identifier":"original"
+},{
+"name": "proton",
+"desc": "a cool, blue theme",
+"auth": "proton.me",
+"identifier":"proton"
+},{
+"name": "solar dark",
+"desc": "a rich blue theme",
+"auth": "ethanschoonover.com/solarized",
+"identifier":"solarised_dark"
+},{
+"name": "solar light",
+"desc": "a pale theme",
+"auth": "ethanschoonover.com/solarized",
+"identifier":"solarised_light"
+},{
+"name": "t-winter",
+"desc": "an ice-cold theme for people who like blue",
+"auth": "hoax",
+"identifier":"t_winter"
+},{
+"name": "zenburn",
+"desc": "a blandly coloured theme for the working class",
+"auth": "github.com/jnurmine/Zenburn",
+"identifier":"zenburn"
+}]
+export { themeList }

--- a/src/theme/dracula.css
+++ b/src/theme/dracula.css
@@ -1,0 +1,23 @@
+/*
+"name": "dracula UI",
+"desc": "an impending grey set of colours",
+"auth": "draculatheme.com",
+*/
+:root.dracula, .dracula{
+	--bg0:#282a36;
+	--bg1:#313442;
+	--bg2:#3B3D4E;
+	--bg3:#44475a;
+	--text:#f8f8f2;
+	--darktext:#e8e8e2;
+
+	--red:#ff5555;
+	--orange:#ffb86c;
+	--yellow:#f1fa8c;
+	--green:#50fa7b;
+	--blue:#89A0E5; /* this is lightened because the default is too dark */
+	--purple:#bd93f9;
+
+  --main:var(--purple);
+	--text-on-color:var(--bg3);
+}

--- a/src/theme/google-dark.css
+++ b/src/theme/google-dark.css
@@ -1,0 +1,25 @@
+/*
+"name": "mUI dark",
+"desc": "the dark colours of alphabet corporation",
+"auth": "Google",
+*/
+
+/* https://m3.material.io/styles/color/overview REFERENCE THIS!!! */
+:root.google-dark, .google-dark{
+	--bg0:#191C1C;
+	--bg1:#181B1B;
+	--bg2:#1F2222;
+	--bg3:#262929;
+	--text:#E0E3E1;
+	--darktext:#CCCECD;
+
+	--red:#6A2028;
+	--orange:#6A3920;
+	--yellow:#6A5720;
+	--green:#386A20;
+	--blue:#206A67;
+	--purple:#460751;
+
+	--main:var(--blue);
+	--text-on-color:var(--text);
+}

--- a/src/theme/google-light.css
+++ b/src/theme/google-light.css
@@ -1,0 +1,25 @@
+/*
+"name": "mUI light",
+"desc": "the light colours of alphabet corporation",
+"auth": "Google",
+*/
+
+/* https://m3.material.io/styles/color/overview */
+:root.google-light, .google-light{
+	--bg0:#fff;
+	--bg1:#ddd;
+	--bg2:#ccc;
+	--bg3:#bbb;
+	--text:#000;
+	--darktext:#222;
+
+	--red:#F39F97;
+	--orange:#F3C797;
+	--yellow:#F3EF97;
+	--green:#B7F397;
+	--blue:#97DCF3;
+	--purple:#E597F3;
+
+	--main:var(--green);
+	--text-on-color:var(--text);
+}

--- a/src/theme/greenhouse.css
+++ b/src/theme/greenhouse.css
@@ -1,0 +1,24 @@
+/*
+"name": "greenhouse",
+"desc": "i cant tell if this is a light or a dark theme to be honest",
+"auth": "hoax",
+*/
+
+:root.greenhouse, .greenhouse{
+	--bg0:#415654;
+	--bg1:#455c5a;
+	--bg2:#3d504e;
+	--bg3:#4c6462;
+	--text:#C9DBD9;
+	--darktext:#749995;
+
+	--red:#69ADB5;
+	--orange:#69ADB5;
+	--yellow:#25808A;
+	--green:#4CD7E0;
+	--blue:#4CD7E0;
+	--purple:#4CD7E0;
+
+  --main:var(--blue);
+	--text-on-color:var(--bg0);
+}

--- a/src/theme/hxve.css
+++ b/src/theme/hxve.css
@@ -1,0 +1,24 @@
+/*
+"name": "hxve terminal",
+"desc": "a boring, slate-grey theme",
+"auth": "hoax",
+*/
+
+:root.hxve, .hxve{
+	--bg0:#161616;
+	--bg1:#1D1D1D;
+	--bg2:#222222;
+	--bg3:#2A2A2A;
+	--text:#B9BBBE;
+	--darktext:#848587;
+
+	--red:#F92672;
+	--orange:#FD971F;
+	--yellow:#E6DB74;
+	--green:#A6E22E;
+	--blue:#66D9EF;
+	--purple:#AE81FF;
+
+  --main:var(--red);
+	--text-on-color:var(--bg0);
+}

--- a/src/theme/monokai.css
+++ b/src/theme/monokai.css
@@ -1,0 +1,24 @@
+/*
+"name": "monokai",
+"desc": "a sandy theme",
+"auth": "Sublime Text 2",
+*/
+
+:root.monokai, .monokai{
+	--bg0:#272822;
+	--bg1:#3e3d32;
+	--bg2:#5A5748;
+	--bg3:#75715e;
+	--text:#f8f8f2;
+	--darktext:#d8d8d2;
+
+	--red:#f92672;
+	--orange:#fd971f;
+	--yellow:#e6db74;
+	--green:#a6e22e;
+	--blue:#66d9ef;
+	--purple:#ae81ff;
+
+  --main:var(--yellow);
+	--text-on-color:var(--bg0);
+}

--- a/src/theme/monokai_pro.css
+++ b/src/theme/monokai_pro.css
@@ -1,0 +1,24 @@
+/*
+"name": "monokai pro",
+"desc": "monokai pro, the sequel to monokai",
+"auth": "Sublime Text 3",
+*/
+
+:root.monokai_pro, .monokai_pro{
+	--bg0:#161821;
+	--bg1:#1e1f2b;
+	--bg2:#232533;
+	--bg3:#282a3a;
+	--text:#EAF2F1;
+	--darktext:#B2B9BD;
+
+	--red:#FF657A;
+	--orange:#FF9B5E;
+	--yellow:#FFD76D;
+	--green:#BAD761;
+	--blue:#9CD1BB;
+	--purple:#C39AC9;
+
+  --main:var(--purple);
+	--text-on-color:var(--bg0);
+}

--- a/src/theme/monokai_prosep.css
+++ b/src/theme/monokai_prosep.css
@@ -1,0 +1,24 @@
+/*
+"name": "monokai desert",
+"desc": "a not-so-light version of monokai pro",
+"auth": "Sublime Text 3 + hoax",
+*/
+
+:root.monokai_prosep, .monokai_prosep{
+	--bg0:#191515;
+	--bg1:#211c1c;
+	--bg2:#272121;
+	--bg3:#2c2525;
+	--text:#EAF2F1;
+	--darktext:#B2B9BD;
+
+	--red:#FF657A;
+	--orange:#FF9B5E;
+	--yellow:#FFD76D;
+	--green:#BAD761;
+	--blue:#9CD1BB;
+	--purple:#A8A9EB;
+
+  --main:var(--orange);
+	--text-on-color:var(--bg0);
+}

--- a/src/theme/nineteeneighty.css
+++ b/src/theme/nineteeneighty.css
@@ -1,0 +1,24 @@
+/*
+"name": "1980",
+"desc": "a retro set of colours",
+"author": "hoax",
+*/
+
+:root.nineteeneighty, .nineteeneighty{
+	--bg0:#262335;
+	--bg1:#171520;
+	--bg2:var(--bg1);
+	--bg3:#2C293D;
+	--text:#d4d4d4;
+	--darktext:#d4d4d4;
+
+	--red:#fe4450;
+	--orange:#ff8b39;
+	--yellow:#FEDE5D;
+	--green:#36f9f6;
+	--blue:#848bbd;
+	--purple:#ff7edb;
+
+	--main:var(--yellow);
+	--text-on-color:var(--bg1);
+}

--- a/src/theme/oled.css
+++ b/src/theme/oled.css
@@ -1,0 +1,24 @@
+/*
+"name": "OLED Black",
+"desc": "for modern display panels",
+"auth": "hoax",
+*/
+
+:root.oled, .oled{
+	--bg0:#000;
+	--bg1:#111;
+	--bg2:#222;
+	--bg3:#333;
+	--text:#EAF2F1;
+	--darktext:#B2B9BD;
+
+	--red:#FF657A;
+	--orange:#FF9B5E;
+	--yellow:#FFD76D;
+	--green:#BAD761;
+	--blue:#9CD1BB;
+	--purple:#A8A9EB;
+
+  --main:var(--orange);
+	--text-on-color:var(--bg0);
+}

--- a/src/theme/original.css
+++ b/src/theme/original.css
@@ -1,0 +1,23 @@
+/*
+"name": "nemusona UI",
+"desc": "a deep-blue set of colours",
+"auth": "nemu",
+*/
+:root.original, .original{
+	--bg0:#001021;
+	--bg1:#001933;
+	--bg2:#00264F;
+	--bg3:#002C5B;
+	--text:#ffffff;
+	--darktext:#dddddd;
+
+	--red:#DC2626;
+	--orange:#ffb86c;
+	--yellow:#f1fa8c;
+	--green:#16A34A;
+	--blue:#00264F;
+	--purple:#bd93f9;
+
+  --main:var(--purple);
+	--text-on-color:#ffffff;
+}

--- a/src/theme/proton.css
+++ b/src/theme/proton.css
@@ -1,0 +1,24 @@
+/*
+"name": "proton",
+"desc": "a cool, blue theme",
+"auth": "proton.me",
+*/
+
+:root.proton, .proton{
+	--bg0:#1e2130;
+	--bg1:#171926;
+	--bg2:#25283a ;
+	--bg3:#34384e;
+	--text:white;
+	--darktext:#979bb0;
+
+	--red:#e53265;
+	--orange:#FD971F;
+	--yellow:#E6DB74;
+	--green:#A6E22E;
+	--blue:#66D9EF;
+	--purple:#AE81FF;
+
+  --main:var(--blue);
+	--text-on-color:var(--bg0);
+}

--- a/src/theme/solarised_dark.css
+++ b/src/theme/solarised_dark.css
@@ -1,0 +1,24 @@
+/*
+"name": "solar dark",
+"desc": "a rich blue theme",
+"auth": "ethanschoonover.com/solarized",
+*/
+
+:root.solarised_dark, .solarised_dark{
+	--bg0:#002b36;
+	--bg1:#022F3A;
+	--bg2:#05323E;
+	--bg3:#073642;
+	--text:#657b83;
+	--darktext:#586e75;
+
+	--red:#dc322f;
+	--orange:#cb4b16;
+	--yellow:#b58900;
+	--green:#859900;
+	--blue:#268bd2;
+	--purple:#6c71c4;
+
+  --main:var(--blue);
+	--text-on-color:var(--bg0);
+}

--- a/src/theme/solarised_light.css
+++ b/src/theme/solarised_light.css
@@ -1,0 +1,24 @@
+/*
+"name": "solar light",
+"desc": "a pale theme",
+"auth": "ethanschoonover.com/solarized",
+*/
+
+:root.solarised_light, .solarised_light{
+	--bg3:#ccc6b3;
+	--bg2:#ddd7c4;
+	--bg1:#eee8d5;
+	--bg0:#fdf6e3;
+	--text:#002b36;
+	--darktext:#073642;
+
+	--red:#dc322f;
+	--orange:#cb4b16;
+	--yellow:#b58900;
+	--green:#859900;
+	--blue:#268bd2;
+	--purple:#6c71c4;
+
+  --main:var(--blue);
+	--text-on-color:var(--bg2);
+}

--- a/src/theme/t_winter.css
+++ b/src/theme/t_winter.css
@@ -1,0 +1,24 @@
+/*
+"name": "t-winter",
+"desc": "an ice-cold theme for people who like blue",
+"auth": "hoax",
+*/
+
+:root.t_winter, .t_winter{
+	--bg0:#011627;
+	--bg1:#041C30;
+	--bg2:#082339;
+	--bg3:#0B2942;
+	--text:#D6DEEB;
+	--darktext:#999999;
+
+	--red:#00BFF9;
+	--orange:#8DEC95;
+	--yellow:#A7DBF7;
+	--green:#82AAFF;
+	--blue:#00BFF9;
+	--purple:#D29FFC;
+
+  --main:var(--red);
+	--text-on-color:var(--bg0);
+}

--- a/src/theme/zenburn.css
+++ b/src/theme/zenburn.css
@@ -1,0 +1,24 @@
+/*
+"name": "zenburn",
+"desc": "a blandly coloured theme for the working class",
+"auth": "github.com/jnurmine/Zenburn",
+*/
+
+:root.zenburn, .zenburn{
+	--bg0:#3f3f3f;
+	--bg1:#373737;
+	--bg2:#3d3d3d;
+	--bg3:#464646;
+	--text:#dcdccc;
+	--darktext:#dcdccc;
+
+	--red:#DCA3A3;
+	--orange:#DFAF8F;
+	--yellow:#F0DFAF;
+	--green:#80D4AA;
+	--blue:#8FAF9F;
+	--purple:#C0BED1;
+
+  --main:var(--red);
+	--text-on-color:var(--bg0);
+}


### PR DESCRIPTION
This fork adds a small icon at the top of the header which allows users to pick their own themes.
![image](https://github.com/Nemusonaneko/frontend/assets/137281947/529214eb-ebb6-4f1d-b9c2-7bceb613611b)
![image](https://github.com/Nemusonaneko/frontend/assets/137281947/8fce89d4-218e-4e51-9433-b0a3eca69382)
![image](https://github.com/Nemusonaneko/frontend/assets/137281947/0cd2d6b9-b08f-429c-8f13-82c1f42c9670)


Themes can support dynamic updates and are handled with css variables, following a common format:
- `--bg0` Darkest background, or Lightest for a light-mode theme
- `--bg1` Darker background, or Lighter for a light-mode theme
- `--bg2` Dark background, or Light for a light-mode theme
- `--bg3` Darkish background, or Lightish for a light-mode theme
- `--red`, `--orange`, `--yellow`, `--green`, `--blue`, `--purple`, are all suppored colours.

The colours are also indexable using material-ui style bracket mixers. EG `--red-30`, `--orange-50`

You can preview a grid of material-ui colours by setting `user.dev=true` in localStorage.
![image](https://github.com/Nemusonaneko/frontend/assets/137281947/8b70ef00-6602-43c7-bdc7-4c5df8d5e617)

Most of the UI has been updates to support theme colours, if ive missed anything, you can use tailwind variables. EG: `bg-[color:var(--bg2)]`, `text-[color:var(--text)]`
